### PR TITLE
맵 모양 변경

### DIFF
--- a/map.c
+++ b/map.c
@@ -10,10 +10,10 @@ void map_boundary(int Map_Size)                             /* Print the boundar
     boundary.x = Map_Size;
     boundary.y = Map_Size;
     for(i = 0; i < Map_Size; i ++)
-        goprint(Map_Size, i, "©ª");
+        goprint(Map_Size, i, "¦­");
     for(i = 0; i < Map_Size; i ++)
-        goprint(i, Map_Size, "©¨");
-    goprint(Map_Size, Map_Size, "©¼");
+        goprint(i, Map_Size, "¦¬");
+    goprint(Map_Size, Map_Size, "¦°");
 }
 
 void map_0(int Map_Size)                      /* Print the outer blocks */
@@ -22,21 +22,21 @@ void map_0(int Map_Size)                      /* Print the outer blocks */
     BLOCK *p = NULL;
     block_head = (BLOCK *)malloc(sizeof(BLOCK));
     for(i = 0, p = block_head; i < Map_Size; i ++){
-        goprint(i, 0, "¨€");
+        goprint(i, 0, "?");
         p->x = i, p->y = 0;
         p->next = (BLOCK *)malloc(sizeof(BLOCK));
         p = p->next;
-        goprint(i, Map_Size - 1, "¨€");
+        goprint(i, Map_Size - 1, "?");
         p->x = i, p->y = Map_Size - 1;
         p->next = (BLOCK *)malloc(sizeof(BLOCK));
         p = p->next;
     }
     for(i = 1; i < Map_Size - 1; i ++){
-        goprint(0, i, "¨€");
+        goprint(0, i, "?");
         p->x = 0, p->y = i;
         p->next = (BLOCK *)malloc(sizeof(BLOCK));
         p = p->next;
-        goprint(Map_Size - 1, i, "¨€");
+        goprint(Map_Size - 1, i, "?");
         p->x = Map_Size - 1, p->y = i;
         if(i == Map_Size - 2){
             p->next = NULL;


### PR DESCRIPTION
맵 경계 부분의 문자열을 변경하였습니다.  그런데, 현재 visual studio에서 코드를 수정한 후 
git 연동작업을 위해 vi편집기로 접속하게 되면 문자를 인식하지 못해 초기의 뱀 모양 유니코드 오류와 유사한 오류가 발생합니다. 이 오류를 수정하고자 합니다. 