### PR TITLE
[Mod] - 함수 map_0의 이름을 map_block으로 수정

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -39,7 +39,7 @@ void welcome(void)
     }
     system("cls");
     if(map_choice == 'y' || map_choice == 'Y')
-        map_0(map_size);
+        map_block(map_size);
 }
 
 void tips(void)
@@ -98,4 +98,12 @@ void progress_bar(void)
         goprint(award_food.x, award_food.y, "  ");
         award_food.x = -1, award_food.y = -1;
     }
+}
+
+void removeCursor()
+{
+	CONSOLE_CURSOR_INFO curInfo;
+	GetConsoleCursorInfo(GetStdHandle(STD_OUTPUT_HANDLE), &curInfo);
+	curInfo.bVisible = 0;
+	SetConsoleCursorInfo(GetStdHandle(STD_OUTPUT_HANDLE), &curInfo);
 }

--- a/map.c
+++ b/map.c
@@ -16,27 +16,27 @@ void map_boundary(int Map_Size)                             /* Print the boundar
     goprint(Map_Size, Map_Size, "©¼");
 }
 
-void map_0(int Map_Size)                      /* Print the outer blocks */
+void map_block(int Map_Size)                      /* Print the outer blocks */
 {
     int i;
     BLOCK *p = NULL;
     block_head = (BLOCK *)malloc(sizeof(BLOCK));
     for(i = 0, p = block_head; i < Map_Size; i ++){
-        goprint(i, 0, "¨€");
+        goprint(i, 0, "?");
         p->x = i, p->y = 0;
         p->next = (BLOCK *)malloc(sizeof(BLOCK));
         p = p->next;
-        goprint(i, Map_Size - 1, "¨€");
+        goprint(i, Map_Size - 1, "?");
         p->x = i, p->y = Map_Size - 1;
         p->next = (BLOCK *)malloc(sizeof(BLOCK));
         p = p->next;
     }
     for(i = 1; i < Map_Size - 1; i ++){
-        goprint(0, i, "¨€");
+        goprint(0, i, "?");
         p->x = 0, p->y = i;
         p->next = (BLOCK *)malloc(sizeof(BLOCK));
         p = p->next;
-        goprint(Map_Size - 1, i, "¨€");
+        goprint(Map_Size - 1, i, "?");
         p->x = Map_Size - 1, p->y = i;
         if(i == Map_Size - 2){
             p->next = NULL;

--- a/map.h
+++ b/map.h
@@ -22,8 +22,11 @@ BOUNDARY boundary;
 int map_size;
 
 void map_boundary(int Map_Size);
-void map_0(int Map_Size);
-void map_1(void);void map_2(void);void map_3(void);void block_free(void);
+void map_block(int Map_Size);
+void map_1(void);
+void map_2(void);
+void map_3(void);
+void block_free(void);
 BLOCK *block_create();
 
 #endif // MAP_H_INCLUDED


### PR DESCRIPTION
interface.c , map.c , map.h 에서
map_0() 함수의 기능 : 콘솔 창(게임 화면)에 block을 출력함
map_0()의 함수명이 함수 자체의 기능을 잘 표현하지 못하므로
함수의 기능을 좀 더 명확히 표현할 수 있는 map_block()이라는 함수명으로 수정함